### PR TITLE
distro: add eject FreeBSD code path

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -1185,9 +1185,17 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
 
     @staticmethod
     def eject_media(device: str) -> None:
-        cmd = ["/lib/udev/cdrom_id", "--eject-media", device]
-        if not uses_systemd():
+        cmd = None
+        if subp.which("eject"):
             cmd = ["eject", device]
+        elif subp.which("/lib/udev/cdrom_id"):
+            cmd = ["/lib/udev/cdrom_id", "--eject-media", device]
+        else:
+            raise subp.ProcessExecutionError(
+                cmd="eject_media_cmd",
+                description="eject command not found",
+                reason="neither eject nor /lib/udev/cdrom_id are found",
+            )
         subp.subp(cmd)
 
 

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -1183,6 +1183,13 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             "/bin/true",
         ] + (["-cf", config_file, interface] if config_file else [interface])
 
+    @staticmethod
+    def eject_media(device: str) -> None:
+        cmd = ["/lib/udev/cdrom_id", "--eject-media", device]
+        if not uses_systemd():
+            cmd = ["eject", device]
+        subp.subp(cmd)
+
 
 def _apply_hostname_transformations_to_url(url: str, transformations: list):
     """

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -226,3 +226,7 @@ class Distro(cloudinit.distros.bsd.BSD):
         return [path, "-l", lease_file, "-p", pid_file] + (
             ["-c", config_file, interface] if config_file else [interface]
         )
+
+    @staticmethod
+    def eject_media(device: str) -> None:
+        subp.subp(["camcontrol", "eject", device])

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1366,6 +1366,7 @@ class DataSourceAzure(sources.DataSource):
         try:
             data = get_metadata_from_fabric(
                 endpoint=self._wireserver_endpoint,
+                distro=self.distro,
                 iso_dev=self._iso_dev,
                 pubkey_info=pubkey_info,
             )

--- a/tests/integration_tests/datasources/test_azure.py
+++ b/tests/integration_tests/datasources/test_azure.py
@@ -1,0 +1,51 @@
+import pytest
+from pycloudlib.cloud import ImageType
+
+from tests.integration_tests.clouds import IntegrationCloud
+from tests.integration_tests.conftest import get_validated_source
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.integration_settings import PLATFORM
+from tests.integration_tests.releases import CURRENT_RELEASE
+from tests.integration_tests.util import verify_clean_log
+
+
+def _check_for_eject_errors(
+    instance: IntegrationInstance,
+):
+    assert "sr0" not in instance.execute("mount")
+    log = instance.read_from_file("/var/log/cloud-init.log")
+    assert "Failed ejecting the provisioning iso" not in log
+    verify_clean_log(log)
+
+
+@pytest.mark.skipif(PLATFORM != "azure", reason="Test is Azure specific")
+def test_azure_eject(session_cloud: IntegrationCloud):
+    """Integration test for GitHub #4732.
+
+    Azure uses `eject` but that is not always available on minimal images.
+    Ensure udev's eject can be used on systemd-enabled systems.
+    """
+    with session_cloud.launch(
+        launch_kwargs={
+            "image_id": session_cloud.cloud_instance.daily_image(
+                CURRENT_RELEASE.series, image_type=ImageType.MINIMAL
+            )
+        }
+    ) as instance:
+        source = get_validated_source(session_cloud)
+        if source.installs_new_version():
+            instance.install_new_cloud_init(
+                source, take_snapshot=False, clean=True
+            )
+            snapshot_id = instance.snapshot()
+            try:
+                with session_cloud.launch(
+                    launch_kwargs={
+                        "image_id": snapshot_id,
+                    }
+                ) as snapshot_instance:
+                    _check_for_eject_errors(snapshot_instance)
+            finally:
+                session_cloud.cloud_instance.delete_image(snapshot_id)
+        else:
+            _check_for_eject_errors(instance)

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -3756,6 +3756,7 @@ class TestProvisioning:
         assert self.mock_azure_get_metadata_from_fabric.mock_calls == [
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev="/dev/sr0",
                 pubkey_info=None,
             )
@@ -3921,11 +3922,13 @@ class TestProvisioning:
         assert self.mock_azure_get_metadata_from_fabric.mock_calls == [
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev="/dev/sr0",
                 pubkey_info=None,
             ),
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev=None,
                 pubkey_info=None,
             ),
@@ -4041,11 +4044,13 @@ class TestProvisioning:
         assert self.mock_azure_get_metadata_from_fabric.mock_calls == [
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev="/dev/sr0",
                 pubkey_info=None,
             ),
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev=None,
                 pubkey_info=None,
             ),
@@ -4197,11 +4202,13 @@ class TestProvisioning:
         assert self.mock_azure_get_metadata_from_fabric.mock_calls == [
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev="/dev/sr0",
                 pubkey_info=None,
             ),
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev=None,
                 pubkey_info=None,
             ),
@@ -4285,6 +4292,7 @@ class TestProvisioning:
         assert self.mock_azure_get_metadata_from_fabric.mock_calls == [
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev="/dev/sr0",
                 pubkey_info=None,
             ),
@@ -4394,6 +4402,7 @@ class TestProvisioning:
         assert self.mock_azure_get_metadata_from_fabric.mock_calls == [
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev="/dev/sr0",
                 pubkey_info=None,
             )


### PR DESCRIPTION
OpenBSD, NetBSD, and Dragonfly all have an eject(1), so they should be covered in the default code path.

FreeBSD however, does not have eject in base. It's an (unmaintained) port. In base, we do however, have camcontrol(8) and cdcontrol(1), both of which have an eject subcommand.

Let's use camcontrol(8) here.

Sponsored by: The FreeBSD Foundation